### PR TITLE
Add exif handling

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,6 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
     - name: "Set up Python"
       uses: actions/setup-python@v5
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,6 @@ repos:
       - id: validate
         name: validate config
         language: system
-        entry: python3 -m src.dailyphoto validate
+        entry: uv run dailyphoto validate
         files: .json|.jpg
         pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Tool to create https://daily.photo"
 readme = "README.md"
 requires-python = ">=3.13"
-dependencies = []
+dependencies = ['Pillow']
 
 [project.scripts]
 dailyphoto = "dailyphoto:cli.main"

--- a/src/dailyphoto/cli.py
+++ b/src/dailyphoto/cli.py
@@ -1,6 +1,7 @@
 import argparse
 
 from . import config
+from .exif import print_exif
 from .generate import generate
 from .metadata import metadata
 from .new import new
@@ -67,6 +68,17 @@ def main(argv: list[str] | None = None) -> int:
         "source_dir",
         help="Source directory for images",
     )
+
+    sp = subparsers.add_parser(
+        "exif",
+        help="Print EXIF data for a specified JPG file",
+    )
+    sp.add_argument(
+        "images",
+        help="Path to the image(s)",
+        nargs="*",
+    )
+
     args = parser.parse_args(argv)
 
     conf = config.read_config(args.config_file)
@@ -92,5 +104,7 @@ def main(argv: list[str] | None = None) -> int:
             conf=conf,
             source_dir=args.source_dir,
         )
+    elif args.function == "exif":
+        return print_exif(args.images)
     else:
         return generate(conf=conf)

--- a/src/dailyphoto/exif.py
+++ b/src/dailyphoto/exif.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+
+from PIL import Image
+from PIL.ExifTags import Base
+from PIL.ExifTags import TAGS
+
+
+def print_exif(image_files: list[str]) -> int:
+    for image in image_files:
+        try:
+            with Image.open(image) as img:
+                exif_data = img.getexif()
+                if exif_data is not None:
+                    for tag_id, value in exif_data.items():
+                        tag = TAGS.get(tag_id, tag_id)
+                        print(f"{tag}: {value}")
+                    for tag_id, value in exif_data.get_ifd(
+                        Image.ExifTags.IFD.Exif,
+                    ).items():
+                        tag = TAGS.get(tag_id, tag_id)
+                        print(f"{tag}: {value}")
+                else:
+                    print(f"No EXIF data found for {image}.")
+        except Exception as e:
+            print(f"Error reading EXIF data from {image}: {e}")
+    return 0
+
+
+def exif_to_metadata(image_file: str, metadata: dict[str, str]) -> None:
+    exif_tags: dict[str, str | None] = {
+        "Make": None,
+        "Model": None,
+        "DateTime": None,
+    }
+
+    with Image.open(image_file) as image:
+        exif_data = image.getexif()
+        if exif_data is not None:
+            for tag in exif_tags.keys():
+                exif_tags[tag] = exif_data.get(Base[tag])
+    if exif_tags["Make"] and exif_tags["Model"] and metadata["camera"] == "":
+        metadata["camera"] = f"{exif_tags['Make']} {exif_tags['Model']}"
+    if exif_tags["DateTime"] and metadata["date"] == "":
+        metadata["date"] = datetime.strftime(
+            datetime.strptime(exif_tags["DateTime"], "%Y:%m:%d %H:%M:%S"),
+            "%Y%m%d",
+        )

--- a/src/dailyphoto/metadata.py
+++ b/src/dailyphoto/metadata.py
@@ -5,6 +5,7 @@ import sys
 
 from . import kitty
 from .config import METADATA_TEMPLATE
+from .exif import exif_to_metadata
 
 
 def edit_json(json_name: str, image_name: str, window_id: str) -> int:
@@ -18,10 +19,12 @@ def edit_json(json_name: str, image_name: str, window_id: str) -> int:
     return subprocess.call(["nvim", json_name])
 
 
-def create_empty_metadata(json_name: str) -> bool:
+def create_empty_metadata(image_name: str, json_name: str) -> bool:
+    metadata = METADATA_TEMPLATE.copy()
+    exif_to_metadata(image_name, metadata)
     with open(json_name, "w") as f:
         json.dump(
-            METADATA_TEMPLATE,
+            metadata,
             f,
             sort_keys=True,
             indent=2,
@@ -39,7 +42,7 @@ def update(
 ) -> int:
     if not os.path.exists(json_name):
         print("Creating missing {json_name}")
-        create_empty_metadata(json_name)
+        create_empty_metadata(image_name, json_name)
     try:
         with open(json_name) as f:
             metadata = json.load(f)

--- a/src/dailyphoto/new.py
+++ b/src/dailyphoto/new.py
@@ -5,7 +5,6 @@ import shutil
 from datetime import datetime
 from datetime import timedelta
 
-
 from . import config
 
 

--- a/src/dailyphoto/queued.py
+++ b/src/dailyphoto/queued.py
@@ -3,7 +3,8 @@ import os
 import shutil
 from typing import Any
 
-from .config import METADATA_TEMPLATE
+from dailyphoto.metadata import create_empty_metadata
+
 from .config import UNUSED
 from .config import UNUSED_IMAGES
 from .config import UNUSED_METADATA
@@ -38,14 +39,7 @@ def move(
     json_name = os.path.join(UNUSED_METADATA, prefix + os.path.extsep + "json")
     print(f"Creating {json_name}")
     try:
-        with open(json_name, "w") as f:
-            json.dump(
-                METADATA_TEMPLATE,
-                f,
-                sort_keys=True,
-                indent=2,
-            )
-            f.write(os.linesep)
+        create_empty_metadata(os.path.join(UNUSED_IMAGES, name), json_name)
     except (
         FileNotFoundError,
         json.decoder.JSONDecodeError,

--- a/uv.lock
+++ b/uv.lock
@@ -6,3 +6,36 @@ requires-python = ">=3.13"
 name = "dailyphoto"
 version = "0.1.0"
 source = { editable = "." }
+dependencies = [
+    { name = "pillow" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pillow" }]
+
+[[package]]
+name = "pillow"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/af/c097e544e7bd278333db77933e535098c259609c4eb3b85381109602fb5b/pillow-11.1.0.tar.gz", hash = "sha256:368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20", size = 46742715 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/31/9ca79cafdce364fd5c980cd3416c20ce1bebd235b470d262f9d24d810184/pillow-11.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ae98e14432d458fc3de11a77ccb3ae65ddce70f730e7c76140653048c71bfcbc", size = 3226640 },
+    { url = "https://files.pythonhosted.org/packages/ac/0f/ff07ad45a1f172a497aa393b13a9d81a32e1477ef0e869d030e3c1532521/pillow-11.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cc1331b6d5a6e144aeb5e626f4375f5b7ae9934ba620c0ac6b3e43d5e683a0f0", size = 3101437 },
+    { url = "https://files.pythonhosted.org/packages/08/2f/9906fca87a68d29ec4530be1f893149e0cb64a86d1f9f70a7cfcdfe8ae44/pillow-11.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:758e9d4ef15d3560214cddbc97b8ef3ef86ce04d62ddac17ad39ba87e89bd3b1", size = 4326605 },
+    { url = "https://files.pythonhosted.org/packages/b0/0f/f3547ee15b145bc5c8b336401b2d4c9d9da67da9dcb572d7c0d4103d2c69/pillow-11.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b523466b1a31d0dcef7c5be1f20b942919b62fd6e9a9be199d035509cbefc0ec", size = 4411173 },
+    { url = "https://files.pythonhosted.org/packages/b1/df/bf8176aa5db515c5de584c5e00df9bab0713548fd780c82a86cba2c2fedb/pillow-11.1.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:9044b5e4f7083f209c4e35aa5dd54b1dd5b112b108648f5c902ad586d4f945c5", size = 4369145 },
+    { url = "https://files.pythonhosted.org/packages/de/7c/7433122d1cfadc740f577cb55526fdc39129a648ac65ce64db2eb7209277/pillow-11.1.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3764d53e09cdedd91bee65c2527815d315c6b90d7b8b79759cc48d7bf5d4f114", size = 4496340 },
+    { url = "https://files.pythonhosted.org/packages/25/46/dd94b93ca6bd555588835f2504bd90c00d5438fe131cf01cfa0c5131a19d/pillow-11.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:31eba6bbdd27dde97b0174ddf0297d7a9c3a507a8a1480e1e60ef914fe23d352", size = 4296906 },
+    { url = "https://files.pythonhosted.org/packages/a8/28/2f9d32014dfc7753e586db9add35b8a41b7a3b46540e965cb6d6bc607bd2/pillow-11.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b5d658fbd9f0d6eea113aea286b21d3cd4d3fd978157cbf2447a6035916506d3", size = 4431759 },
+    { url = "https://files.pythonhosted.org/packages/33/48/19c2cbe7403870fbe8b7737d19eb013f46299cdfe4501573367f6396c775/pillow-11.1.0-cp313-cp313-win32.whl", hash = "sha256:f86d3a7a9af5d826744fabf4afd15b9dfef44fe69a98541f666f66fbb8d3fef9", size = 2291657 },
+    { url = "https://files.pythonhosted.org/packages/3b/ad/285c556747d34c399f332ba7c1a595ba245796ef3e22eae190f5364bb62b/pillow-11.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:593c5fd6be85da83656b93ffcccc2312d2d149d251e98588b14fbc288fd8909c", size = 2626304 },
+    { url = "https://files.pythonhosted.org/packages/e5/7b/ef35a71163bf36db06e9c8729608f78dedf032fc8313d19bd4be5c2588f3/pillow-11.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:11633d58b6ee5733bde153a8dafd25e505ea3d32e261accd388827ee987baf65", size = 2375117 },
+    { url = "https://files.pythonhosted.org/packages/79/30/77f54228401e84d6791354888549b45824ab0ffde659bafa67956303a09f/pillow-11.1.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:70ca5ef3b3b1c4a0812b5c63c57c23b63e53bc38e758b37a951e5bc466449861", size = 3230060 },
+    { url = "https://files.pythonhosted.org/packages/ce/b1/56723b74b07dd64c1010fee011951ea9c35a43d8020acd03111f14298225/pillow-11.1.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8000376f139d4d38d6851eb149b321a52bb8893a88dae8ee7d95840431977081", size = 3106192 },
+    { url = "https://files.pythonhosted.org/packages/e1/cd/7bf7180e08f80a4dcc6b4c3a0aa9e0b0ae57168562726a05dc8aa8fa66b0/pillow-11.1.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ee85f0696a17dd28fbcfceb59f9510aa71934b483d1f5601d1030c3c8304f3c", size = 4446805 },
+    { url = "https://files.pythonhosted.org/packages/97/42/87c856ea30c8ed97e8efbe672b58c8304dee0573f8c7cab62ae9e31db6ae/pillow-11.1.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:dd0e081319328928531df7a0e63621caf67652c8464303fd102141b785ef9547", size = 4530623 },
+    { url = "https://files.pythonhosted.org/packages/ff/41/026879e90c84a88e33fb00cc6bd915ac2743c67e87a18f80270dfe3c2041/pillow-11.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e63e4e5081de46517099dc30abe418122f54531a6ae2ebc8680bcd7096860eab", size = 4465191 },
+    { url = "https://files.pythonhosted.org/packages/e5/fb/a7960e838bc5df57a2ce23183bfd2290d97c33028b96bde332a9057834d3/pillow-11.1.0-cp313-cp313t-win32.whl", hash = "sha256:dda60aa465b861324e65a78c9f5cf0f4bc713e4309f83bc387be158b077963d9", size = 2295494 },
+    { url = "https://files.pythonhosted.org/packages/d7/6c/6ec83ee2f6f0fda8d4cf89045c6be4b0373ebfc363ba8538f8c999f63fcd/pillow-11.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ad5db5781c774ab9a9b2c4302bbf0c1014960a0a7be63278d13ae6fdf88126fe", size = 2631595 },
+    { url = "https://files.pythonhosted.org/packages/cf/6c/41c21c6c8af92b9fea313aa47c75de49e2f9a467964ee33eb0135d47eb64/pillow-11.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:67cd427c68926108778a9005f2a04adbd5e67c442ed21d95389fe1d595458756", size = 2377651 },
+]


### PR DESCRIPTION
# `exif` cli tool
Adds an exif command to dump the visible exif metadata for debugging

# `exif_to_metadata`
Modified places where I create a new metadata json to automatically
prefill the json with data available in the exif data. Currently I can
only really support make, model, and taken date unfortunately.