### PR TITLE
Use pydantic for metadata

### DIFF
--- a/src/dailyphoto/cli.py
+++ b/src/dailyphoto/cli.py
@@ -52,11 +52,6 @@ def main(argv: list[str] | None = None) -> int:
         default=False,
     )
     sp.add_argument(
-        "--fields",
-        help="Comma separate list of fields to check if a file needs editing.",
-        default=None,
-    )
-    sp.add_argument(
         "source_dir",
         help="Source directory for images",
     )
@@ -96,7 +91,6 @@ def main(argv: list[str] | None = None) -> int:
     elif args.function == "metadata":
         return metadata(
             always_edit=args.always_edit,
-            fields_csv=args.fields,
             source_dir=args.source_dir,
         )
     elif args.function == "queue":

--- a/src/dailyphoto/cli.py
+++ b/src/dailyphoto/cli.py
@@ -90,6 +90,7 @@ def main(argv: list[str] | None = None) -> int:
         return validate(conf=conf)
     elif args.function == "metadata":
         return metadata(
+            conf=conf,
             always_edit=args.always_edit,
             source_dir=args.source_dir,
         )

--- a/src/dailyphoto/config.py
+++ b/src/dailyphoto/config.py
@@ -4,12 +4,9 @@ import os
 from datetime import datetime
 from typing import Annotated
 
-from annotated_types import Len
 from pydantic import BaseModel
 from pydantic import BeforeValidator
-from pydantic import ConfigDict
 from pydantic import PlainSerializer
-from pydantic import ValidationError
 
 UNUSED = "queued"
 UNUSED_IMAGES = os.path.join(UNUSED, "images")
@@ -26,58 +23,6 @@ ShortDatetime = Annotated[
     BeforeValidator(lambda ds: datetime.strptime(ds, "%Y%m%d")),
     PlainSerializer(lambda dt: dt.strftime("%Y%m%d") if dt else ""),
 ]
-
-
-class MetadataEditable(BaseModel):
-    """Represents newly generated image metadata. Used for adding + editing images when fields might be unset"""
-
-    model_config = ConfigDict(extra="allow")
-    alt: str = ""
-    camera: str = ""
-    date: ShortDatetime | str | None = None
-    film: str = ""
-    subtitle: str = ""
-
-
-class Metadata(BaseModel):
-    """
-    Represents the final image metadata.
-    Used for validation and generation to ensure that all fields are filled in and have certain properties.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-    alt: Annotated[str, Len(min_length=1)]
-    camera: Annotated[str, Len(min_length=1)]
-    date: ShortDatetime
-    film: Annotated[str, Len(min_length=1)]
-    subtitle: Annotated[str, Len(min_length=1)]
-
-
-def get_metadata_filename(metadata_dir: str, image: str) -> str:
-    return os.path.join(
-        metadata_dir,
-        os.path.splitext(os.path.basename(image))[0] + ".json",
-    )
-
-
-def read_metadata(metadata_file: str) -> Metadata | None:
-    try:
-        with open(metadata_file) as c:
-            parsed = json.load(c)
-            return Metadata.model_validate(parsed)
-    except (FileNotFoundError, json.decoder.JSONDecodeError, ValidationError) as e:
-        print(f"Unable to load metadata: {metadata_file}.", str(e))
-        return None
-
-
-def write_metadata(metadata_file: str, metadata: Metadata | MetadataEditable) -> None:
-    try:
-        with open(metadata_file, "w") as c:
-            c.write(metadata.model_dump_json(indent=2))
-            # include a final line ending
-            c.write("\n")
-    except OSError as e:
-        print(f"Unable to write metadata: {metadata_file}.", e)
 
 
 class Date(BaseModel):

--- a/src/dailyphoto/config.py
+++ b/src/dailyphoto/config.py
@@ -18,26 +18,19 @@ OUTPUT_DIR = "generated"
 OUTPUT_IMAGES = "images"
 TEMPLATE = "template.html"
 
-METADATA_TEMPLATE = {
-    "alt": "",
-    "camera": "",
-    "date": "",
-    "film": "",
-    "subtitle": "",
-}
 
 ShortDatetime = Annotated[
     datetime,
     BeforeValidator(lambda ds: datetime.strptime(ds, "%Y%m%d")),
-    PlainSerializer(lambda dt: dt.strftime("%Y%m%d")),
+    PlainSerializer(lambda dt: dt.strftime("%Y%m%d") if dt else ""),
 ]
 
 
 class Metadata(BaseModel):
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="allow")
     alt: str = ""
     camera: str = ""
-    date: ShortDatetime | str = ""
+    date: ShortDatetime | None = None
     film: str = ""
     subtitle: str = ""
 

--- a/src/dailyphoto/config.py
+++ b/src/dailyphoto/config.py
@@ -6,6 +6,7 @@ from typing import Annotated
 
 from pydantic import BaseModel
 from pydantic import BeforeValidator
+from pydantic import ConfigDict
 from pydantic import PlainSerializer
 
 UNUSED = "queued"
@@ -33,6 +34,7 @@ ShortDatetime = Annotated[
 
 
 class Metadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
     alt: str = ""
     camera: str = ""
     date: ShortDatetime | str = ""
@@ -52,8 +54,7 @@ def read_metadata(metadata_file: str) -> Metadata | None:
         with open(metadata_file) as c:
             parsed = json.load(c)
             return Metadata.model_validate(parsed)
-
-    except (FileNotFoundError, json.decoder.JSONDecodeError) as e:
+    except FileNotFoundError as e:
         print(f"Unable to load metadata: {metadata_file}.", e)
         return None
 
@@ -64,7 +65,6 @@ def write_metadata(metadata_file: str, metadata: Metadata) -> None:
             c.write(metadata.model_dump_json(indent=2))
             # include a final line ending
             c.write("\n")
-
     except OSError as e:
         print(f"Unable to write metadata: {metadata_file}.", e)
 

--- a/src/dailyphoto/config.py
+++ b/src/dailyphoto/config.py
@@ -1,12 +1,8 @@
 import functools
 import json
 import os
-from datetime import datetime
-from typing import Annotated
 
-from pydantic import BaseModel
-from pydantic import BeforeValidator
-from pydantic import PlainSerializer
+from .types import Config
 
 UNUSED = "queued"
 UNUSED_IMAGES = os.path.join(UNUSED, "images")
@@ -16,22 +12,6 @@ METADATA_DIR = "current/metadata"
 OUTPUT_DIR = "generated"
 OUTPUT_IMAGES = "images"
 TEMPLATE = "template.html"
-
-
-ShortDatetime = Annotated[
-    datetime,
-    BeforeValidator(lambda ds: datetime.strptime(ds, "%Y%m%d")),
-    PlainSerializer(lambda dt: dt.strftime("%Y%m%d") if dt else ""),
-]
-
-
-class Date(BaseModel):
-    day: ShortDatetime
-    filename: str
-
-
-class Config(BaseModel):
-    dates: list[Date]
 
 
 @functools.cache

--- a/src/dailyphoto/config.py
+++ b/src/dailyphoto/config.py
@@ -33,11 +33,11 @@ ShortDatetime = Annotated[
 
 
 class Metadata(BaseModel):
-    alt: str
-    camera: str
-    date: ShortDatetime | str
-    film: str
-    subtitle: str
+    alt: str = ""
+    camera: str = ""
+    date: ShortDatetime | str = ""
+    film: str = ""
+    subtitle: str = ""
 
 
 def get_metadata_filename(metadata_dir: str, image: str) -> str:

--- a/src/dailyphoto/exif.py
+++ b/src/dailyphoto/exif.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from dailyphoto.config import Metadata
+from dailyphoto.config import MetadataEditable
 from PIL import Image
 from PIL.ExifTags import Base
 from PIL.ExifTags import TAGS
@@ -27,7 +27,7 @@ def print_exif(image_files: list[str]) -> int:
     return 0
 
 
-def exif_to_metadata(image_file: str, metadata: Metadata) -> None:
+def exif_to_metadata(image_file: str, metadata: MetadataEditable) -> None:
     with Image.open(image_file) as image:
         exif_data = image.getexif()
     if exif_data is None:

--- a/src/dailyphoto/exif.py
+++ b/src/dailyphoto/exif.py
@@ -4,7 +4,7 @@ from PIL import Image
 from PIL.ExifTags import Base
 from PIL.ExifTags import TAGS
 
-from .metadata import MetadataEditable
+from .types import MetadataEditable
 
 
 def print_exif(image_files: list[str]) -> int:

--- a/src/dailyphoto/exif.py
+++ b/src/dailyphoto/exif.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from dailyphoto.config import Metadata
 from PIL import Image
 from PIL.ExifTags import Base
 from PIL.ExifTags import TAGS
@@ -26,7 +27,7 @@ def print_exif(image_files: list[str]) -> int:
     return 0
 
 
-def exif_to_metadata(image_file: str, metadata: dict[str, str]) -> None:
+def exif_to_metadata(image_file: str, metadata: Metadata) -> None:
     with Image.open(image_file) as image:
         exif_data = image.getexif()
     if exif_data is None:
@@ -45,11 +46,11 @@ def exif_to_metadata(image_file: str, metadata: dict[str, str]) -> None:
             or None
         )
 
-    if make and model and metadata["camera"] == "":
-        metadata["camera"] = f"{make} {model}"
+    if make and model and metadata.camera == "":
+        metadata.camera = f"{make} {model}"
     # Always trust the camera for digital cameras
     if exif_date and make == "FUJIFILM":
-        metadata["date"] = exif_date
+        metadata.date = exif_date
     # seed the date if we don't have one at all
-    elif exif_date and metadata["date"] == "":
-        metadata["date"] = exif_date
+    elif exif_date and metadata.date == "":
+        metadata.date = exif_date

--- a/src/dailyphoto/exif.py
+++ b/src/dailyphoto/exif.py
@@ -38,13 +38,7 @@ def exif_to_metadata(image_file: str, metadata: Metadata) -> None:
     dto = ifd_tags.get(Base["DateTimeOriginal"])
     exif_date = None
     if dto:
-        exif_date = (
-            datetime.strftime(
-                datetime.strptime(dto, "%Y:%m:%d %H:%M:%S"),
-                "%Y%m%d",
-            )
-            or None
-        )
+        exif_date = datetime.strptime(dto, "%Y:%m:%d %H:%M:%S") or None
 
     if make and model and metadata.camera == "":
         metadata.camera = f"{make} {model}"

--- a/src/dailyphoto/exif.py
+++ b/src/dailyphoto/exif.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 
-from dailyphoto.config import MetadataEditable
 from PIL import Image
 from PIL.ExifTags import Base
 from PIL.ExifTags import TAGS
+
+from .metadata import MetadataEditable
 
 
 def print_exif(image_files: list[str]) -> int:

--- a/src/dailyphoto/generate.py
+++ b/src/dailyphoto/generate.py
@@ -8,12 +8,12 @@ import tarfile
 from typing import TypedDict
 
 from .config import Config
-from .config import get_metadata_filename
 from .config import IMAGES
 from .config import METADATA_DIR
 from .config import OUTPUT_DIR
 from .config import OUTPUT_IMAGES
 from .config import TEMPLATE
+from .metadata import get_metadata_filename
 
 RSS_FEED_HEADER = """\
 <?xml version="1.0" encoding="utf-8"?>
@@ -114,6 +114,7 @@ def generate_day(
 
     print(f"Generating {output_name}")
 
+    # TODO replace with new metadtat
     with open(metadata_file) as f:
         metadata = json.load(f)
 

--- a/src/dailyphoto/metadata.py
+++ b/src/dailyphoto/metadata.py
@@ -3,8 +3,12 @@ import os
 import subprocess
 import sys
 
+from pydantic import ValidationError
+
 from . import kitty
-from .config import METADATA_TEMPLATE
+from .config import Metadata
+from .config import read_metadata
+from .config import write_metadata
 from .exif import exif_to_metadata
 
 
@@ -19,64 +23,37 @@ def edit_json(json_name: str, image_name: str, window_id: str) -> int:
     return subprocess.call(["nvim", json_name])
 
 
-def write_metadata(metadata: dict[str, str], json_name: str) -> None:
-    try:
-        with open(json_name, "w") as f:
-            json.dump(
-                metadata,
-                f,
-                sort_keys=True,
-                indent=2,
-            )
-            f.write(os.linesep)
-    except OSError as e:
-        print(f"Error writing to file {json_name}: {e}")
-
-
 def update(
     image_name: str,
     json_name: str,
     always_edit: bool,
     window_id: str,
-    fields: set[str] | None,
 ) -> int:
-    if not os.path.exists(json_name):
-        print("Creating missing {json_name}")
-        metadata = METADATA_TEMPLATE.copy()
-    else:
-        try:
-            with open(json_name) as f:
-                metadata = json.load(f)
-        except FileNotFoundError as e:
-            print(f"Unable to load metadata file: {json_name}.", e)
-            return 1
-        except json.decoder.JSONDecodeError as e:
-            # if the json is garbage, give it to me to edit it
-            print(f"Unable to parse metadata file: {json_name}.", e)
-            return edit_json(json_name, image_name, window_id)
+    try:
+        metadata = read_metadata(json_name) or Metadata()
+    except (json.decoder.JSONDecodeError, ValidationError) as e:
+        # if the json is garbage, give it to me to edit it
+        print(f"Unable to parse metadata file: {json_name}.", e)
+        return edit_json(json_name, image_name, window_id)
 
     # create or fix the metadata dict with data from the image
     exif_to_metadata(image_name, metadata)
-    write_metadata(metadata, json_name)
+    write_metadata(json_name, metadata)
 
+    # TODO extra
+    metadata.model_extra
     edit = always_edit
-    if fields is None:
-        # if we aren't editing a specific field, calculate symmetric
-        # distance of key sets to find if there are missing keys
-        missing_fields = set(metadata.keys()) ^ set(METADATA_TEMPLATE.keys())
-        if len(missing_fields) > 0:
-            print(f"{json_name} is missing {missing_fields}")
-        edit = len(missing_fields) > 0
+    # TODO doesn't work -- converts date to str
+    for k, v in metadata.model_dump().items():
+        if k == "date" and isinstance(v, str):
+            edit = True
 
-    for k, v in metadata.items():
-        if fields and k not in fields:
-            continue
         if v == "":
             edit = True
 
     if edit or always_edit:
         json.dump(
-            metadata,
+            metadata.model_dump(),
             sys.stdout,
             sort_keys=True,
             indent=2,
@@ -92,11 +69,8 @@ def update(
 def metadata(
     *,
     always_edit: bool,
-    fields_csv: str | None,
     source_dir: str,
 ) -> int:
-    fields = set(fields_csv.split(",")) if fields_csv else None
-
     id = kitty.new_window()
     kitty.set_layout("horizontal")
 
@@ -112,7 +86,6 @@ def metadata(
                 os.path.join(metadata_dir, prefix + os.path.extsep + "json"),
                 always_edit,
                 id,
-                fields,
             )
             # -1 is the signal to quit since processes return positive numbers
             if ret < 0:

--- a/src/dailyphoto/metadata.py
+++ b/src/dailyphoto/metadata.py
@@ -2,42 +2,14 @@ import json
 import os
 import subprocess
 import sys
-from typing import Annotated
 
-from annotated_types import Len
-from pydantic import BaseModel
-from pydantic import ConfigDict
 from pydantic import ValidationError
 
 from . import kitty
 from .config import Config
-from .config import ShortDatetime
 from .exif import exif_to_metadata
-
-
-class MetadataEditable(BaseModel):
-    """Represents newly generated image metadata. Used for adding + editing images when fields might be unset"""
-
-    model_config = ConfigDict(extra="allow")
-    alt: str = ""
-    camera: str = ""
-    date: ShortDatetime | str | None = None
-    film: str = ""
-    subtitle: str = ""
-
-
-class Metadata(BaseModel):
-    """
-    Represents the final image metadata.
-    Used for validation and generation to ensure that all fields are filled in and have certain properties.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-    alt: Annotated[str, Len(min_length=1)]
-    camera: Annotated[str, Len(min_length=1)]
-    date: ShortDatetime
-    film: Annotated[str, Len(min_length=1)]
-    subtitle: Annotated[str, Len(min_length=1)]
+from .types import Metadata
+from .types import MetadataEditable
 
 
 def get_metadata_filename(metadata_dir: str, image: str) -> str:

--- a/src/dailyphoto/metadata.py
+++ b/src/dailyphoto/metadata.py
@@ -2,15 +2,69 @@ import json
 import os
 import subprocess
 import sys
+from typing import Annotated
 
+from annotated_types import Len
+from pydantic import BaseModel
+from pydantic import ConfigDict
 from pydantic import ValidationError
 
 from . import kitty
 from .config import Config
-from .config import Metadata
-from .config import MetadataEditable
-from .config import write_metadata
+from .config import ShortDatetime
 from .exif import exif_to_metadata
+
+
+class MetadataEditable(BaseModel):
+    """Represents newly generated image metadata. Used for adding + editing images when fields might be unset"""
+
+    model_config = ConfigDict(extra="allow")
+    alt: str = ""
+    camera: str = ""
+    date: ShortDatetime | str | None = None
+    film: str = ""
+    subtitle: str = ""
+
+
+class Metadata(BaseModel):
+    """
+    Represents the final image metadata.
+    Used for validation and generation to ensure that all fields are filled in and have certain properties.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    alt: Annotated[str, Len(min_length=1)]
+    camera: Annotated[str, Len(min_length=1)]
+    date: ShortDatetime
+    film: Annotated[str, Len(min_length=1)]
+    subtitle: Annotated[str, Len(min_length=1)]
+
+
+def get_metadata_filename(metadata_dir: str, image: str) -> str:
+    return os.path.join(
+        metadata_dir,
+        os.path.splitext(os.path.basename(image))[0] + ".json",
+    )
+
+
+def read_metadata(metadata_file: str) -> Metadata | None:
+    try:
+        with open(metadata_file) as c:
+            parsed = json.load(c)
+            return Metadata.model_validate(parsed)
+    except (FileNotFoundError, json.decoder.JSONDecodeError, ValidationError) as e:
+        print(f"Unable to load metadata: {metadata_file}.", str(e))
+        return None
+
+
+def write_metadata(metadata_file: str, metadata: Metadata | MetadataEditable) -> None:
+    try:
+        with open(metadata_file, "w") as c:
+            c.write(metadata.model_dump_json(indent=2))
+            # include a final line ending
+            c.write("\n")
+    except OSError as e:
+        print(f"Unable to write metadata: {metadata_file}.", e)
 
 
 def edit_json(json_name: str, image_name: str, window_id: str) -> int:

--- a/src/dailyphoto/metadata.py
+++ b/src/dailyphoto/metadata.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError
 
 from . import kitty
 from .config import Config
-from .config import Metadata
+from .config import MetadataEditable
 from .config import read_metadata
 from .config import write_metadata
 from .exif import exif_to_metadata
@@ -32,7 +32,8 @@ def update(
     window_id: str,
 ) -> int:
     try:
-        metadata = read_metadata(json_name) or Metadata()
+        # TODO read_metadata needs to do a editable
+        metadata = read_metadata(json_name, MetadataEditable) or MetadataEditable()
     except (json.decoder.JSONDecodeError, ValidationError) as e:
         # if the json is garbage, give it to me to edit it
         print(f"Unable to parse metadata file: {json_name}.", e)
@@ -42,6 +43,7 @@ def update(
     exif_to_metadata(image_name, metadata)
     write_metadata(json_name, metadata)
 
+    # TODO i think we load as metadata here and go through the errors, but i think that means we can probably flip this function around asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdf
     edit = always_edit or not validate_metadata(json_name, metadata)
 
     if edit or always_edit:

--- a/src/dailyphoto/metadata.py
+++ b/src/dailyphoto/metadata.py
@@ -3,13 +3,12 @@ import os
 import subprocess
 import sys
 
-from dailyphoto.validate import validate_metadata
 from pydantic import ValidationError
 
 from . import kitty
 from .config import Config
+from .config import Metadata
 from .config import MetadataEditable
-from .config import read_metadata
 from .config import write_metadata
 from .exif import exif_to_metadata
 
@@ -31,20 +30,36 @@ def update(
     always_edit: bool,
     window_id: str,
 ) -> int:
+    # First attempt to validate the existing on disk metadata file to see if it needs edited.
+    edit = always_edit
+    json_dict = None
     try:
-        # TODO read_metadata needs to do a editable
-        metadata = read_metadata(json_name, MetadataEditable) or MetadataEditable()
-    except (json.decoder.JSONDecodeError, ValidationError) as e:
-        # if the json is garbage, give it to me to edit it
+        with open(json_name) as c:
+            json_dict = json.load(c)
+    except FileNotFoundError as e:
+        print(f"Creating new metadata {json_name}.", e)
+    except json.decoder.JSONDecodeError as e:
+        # if the json is garbage just to edit it
         print(f"Unable to parse metadata file: {json_name}.", e)
         return edit_json(json_name, image_name, window_id)
 
-    # create or fix the metadata dict with data from the image
+    metadata = MetadataEditable()
+    if json_dict is not None:
+        try:
+            Metadata.model_validate(json_dict)
+        except ValidationError as valid_e:
+            # If it fails to validate, we need to edit.
+            print(f"Metadata file {json_name} failed to validate:")
+            for x in valid_e.errors():
+                print(f"\tField {x['loc'][0]}: {x['msg']}")
+            edit = True
+
+        # Load existing data
+        metadata = metadata.model_validate(json_dict)
+
+    # Update metadata with data from the image
     exif_to_metadata(image_name, metadata)
     write_metadata(json_name, metadata)
-
-    # TODO i think we load as metadata here and go through the errors, but i think that means we can probably flip this function around asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdf
-    edit = always_edit or not validate_metadata(json_name, metadata)
 
     if edit or always_edit:
         json.dump(
@@ -57,7 +72,6 @@ def update(
         print(f"editing {os.path.basename(image_name)}")
         return edit_json(json_name, image_name, window_id)
     else:
-        print(f"No need to edit {json_name}")
         return 0
 
 

--- a/src/dailyphoto/new.py
+++ b/src/dailyphoto/new.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 
 from . import config
 from .metadata import get_metadata_filename
+from .types import Date
 
 
 def new(
@@ -129,7 +130,7 @@ def new_image(
         print(f"{old_metadata_file} does not exist, no need to move")
 
     conf.dates.append(
-        config.Date.model_validate({"day": new_date, "filename": new_image}),
+        Date.model_validate({"day": new_date, "filename": new_image}),
     )
     print(f"Writing {config_file}")
     config.write_config(config_file, conf)

--- a/src/dailyphoto/new.py
+++ b/src/dailyphoto/new.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from datetime import timedelta
 
 from . import config
+from .metadata import get_metadata_filename
 
 
 def new(
@@ -113,12 +114,12 @@ def new_image(
     shutil.move(old_image_path, new_image_path)
 
     # Try to move the metadata file
-    old_metadata_file = config.get_metadata_filename(
+    old_metadata_file = get_metadata_filename(
         config.UNUSED_METADATA,
         new_image,
     )
     if os.path.exists(old_metadata_file):
-        new_metadata_file = config.get_metadata_filename(
+        new_metadata_file = get_metadata_filename(
             config.METADATA_DIR,
             new_image,
         )

--- a/src/dailyphoto/queued.py
+++ b/src/dailyphoto/queued.py
@@ -2,14 +2,13 @@ import os
 import shutil
 
 from .config import Config
-from .config import Date
 from .config import UNUSED
 from .config import UNUSED_IMAGES
 from .config import UNUSED_METADATA
 
 
-def unused(dates: list[Date], new_image: str) -> bool:
-    for date in dates:
+def unused(conf: Config, new_image: str) -> bool:
+    for date in conf.dates:
         if date.filename == new_image:
             print(f"{date.filename} is already used on {date.day}")
             return False
@@ -38,8 +37,6 @@ def move(
 
 
 def queue_images(*, conf: Config, source_dir: str) -> int:
-    dates = conf.dates
-
     if not os.path.exists(source_dir):
         print(f"Error: unable to list {source_dir}")
         return 1
@@ -53,7 +50,7 @@ def queue_images(*, conf: Config, source_dir: str) -> int:
 
     with os.scandir(source_dir) as it:
         for entry in it:
-            if entry.is_file() and unused(dates, entry.name):
+            if entry.is_file() and unused(conf, entry.name):
                 ret = move(source_dir, entry.name)
                 if ret != 0:
                     return ret

--- a/src/dailyphoto/types.py
+++ b/src/dailyphoto/types.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+from typing import Annotated
+
+from annotated_types import Len
+from pydantic import BaseModel
+from pydantic import BeforeValidator
+from pydantic import ConfigDict
+from pydantic import PlainSerializer
+
+
+ShortDatetime = Annotated[
+    datetime,
+    BeforeValidator(lambda ds: datetime.strptime(ds, "%Y%m%d")),
+    PlainSerializer(lambda dt: dt.strftime("%Y%m%d") if dt else ""),
+]
+
+
+class Date(BaseModel):
+    day: ShortDatetime
+    filename: str
+
+
+class Config(BaseModel):
+    dates: list[Date]
+
+
+class MetadataEditable(BaseModel):
+    """Represents newly generated image metadata. Used for adding + editing images when fields might be unset"""
+
+    model_config = ConfigDict(extra="allow")
+    alt: str = ""
+    camera: str = ""
+    date: ShortDatetime | str | None = None
+    film: str = ""
+    subtitle: str = ""
+
+
+class Metadata(BaseModel):
+    """
+    Represents the final image metadata.
+    Used for validation and generation to ensure that all fields are filled in and have certain properties.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    alt: Annotated[str, Len(min_length=1)]
+    camera: Annotated[str, Len(min_length=1)]
+    date: ShortDatetime
+    film: Annotated[str, Len(min_length=1)]
+    subtitle: Annotated[str, Len(min_length=1)]

--- a/src/dailyphoto/validate.py
+++ b/src/dailyphoto/validate.py
@@ -1,5 +1,4 @@
 import os
-from datetime import datetime
 from typing import Any
 
 from .config import Config
@@ -11,19 +10,6 @@ from .config import read_metadata
 
 def valid_str(value: Any) -> bool:
     return isinstance(value, str) and len(value) > 0
-
-
-def valid_date(value: Any) -> bool:
-    if not isinstance(value, str):
-        return False
-    day = value
-    if len(day) != 8:
-        return False
-    try:
-        datetime.strptime(day, "%Y%m%d")
-    except ValueError:
-        return False
-    return True
 
 
 def validate(*, conf: Config) -> int:

--- a/src/dailyphoto/validate.py
+++ b/src/dailyphoto/validate.py
@@ -15,6 +15,8 @@ def valid_str(value: Any) -> bool:
 
 
 def validate_metadata(meta_filename: str, meta: Metadata) -> bool:
+    # TODO we should have two metadata types -- one for complete metadata and one for ones we are working on before
+    # committing
     ret = True
     if meta.model_extra and len(meta.model_extra.items()) > 0:
         print(f"{meta_filename} has extra fields: {meta.model_extra}")

--- a/src/dailyphoto/validate.py
+++ b/src/dailyphoto/validate.py
@@ -1,8 +1,5 @@
 import os
-from json import JSONDecodeError
 from typing import Any
-
-from pydantic import ValidationError
 
 from .config import Config
 from .config import get_metadata_filename
@@ -67,16 +64,7 @@ def validate(*, conf: Config) -> int:
             ret += 1
 
         metadata_file = get_metadata_filename(METADATA_DIR, date.filename)
-        try:
-            metadata = read_metadata(metadata_file, Metadata)
-        except JSONDecodeError as e:
-            ret += 1
-            print(f"Entry {date.day}: {metadata_file} json parsing failed\n{e}")
-            continue
-        except ValidationError as e:
-            ret += 1
-            print(f"Entry {date.day}: {metadata_file} validation failed\n{str(e)}")
-            continue
+        metadata = read_metadata(metadata_file)
 
         if metadata is None:
             ret += 1

--- a/src/dailyphoto/validate.py
+++ b/src/dailyphoto/validate.py
@@ -4,43 +4,12 @@ from typing import Any
 from .config import Config
 from .config import get_metadata_filename
 from .config import IMAGES
-from .config import Metadata
 from .config import METADATA_DIR
 from .config import read_metadata
 
 
 def valid_str(value: Any) -> bool:
     return isinstance(value, str) and len(value) > 0
-
-
-def validate_metadata(meta_filename: str, meta: Metadata) -> bool:
-    # TODO remove after validating that we don't need this
-    ret = True
-    if meta.model_extra and len(meta.model_extra.items()) > 0:
-        print(f"{meta_filename} has extra fields: {meta.model_extra}")
-        ret = False
-
-    if not valid_str(meta.alt):
-        print(f"{meta_filename} has invalid alt text: {meta.alt}")
-        ret = False
-
-    if not valid_str(meta.camera):
-        print(f"{meta_filename} has invalid camera text: {meta.camera}")
-        ret = False
-
-    if not valid_str(meta.film):
-        print(f"{meta_filename} has invalid film text: {meta.film}")
-        ret = False
-
-    if not valid_str(meta.subtitle):
-        print(f"{meta_filename} has invalid subtitle text: {meta.subtitle}")
-        ret = False
-
-    if isinstance(meta.date, str):
-        print(f"{meta_filename} has invalid date: {meta.date}")
-        ret = False
-
-    return ret
 
 
 def validate(*, conf: Config) -> int:

--- a/src/dailyphoto/validate.py
+++ b/src/dailyphoto/validate.py
@@ -39,6 +39,9 @@ def validate(*, conf: Config) -> int:
             print(f"Entry {date} unable to load {metadata_file}")
             continue
 
+        # TODO extra should we allow them? how to ahndle
+        metadata.model_extra
+
         # Validate field values.
         valid_str(metadata.alt)
         valid_str(metadata.camera)

--- a/src/dailyphoto/validate.py
+++ b/src/dailyphoto/validate.py
@@ -1,10 +1,10 @@
 import os
 
 from .config import Config
-from .config import get_metadata_filename
 from .config import IMAGES
 from .config import METADATA_DIR
-from .config import read_metadata
+from .metadata import get_metadata_filename
+from .metadata import read_metadata
 
 
 def validate(*, conf: Config) -> int:

--- a/src/dailyphoto/validate.py
+++ b/src/dailyphoto/validate.py
@@ -1,15 +1,10 @@
 import os
-from typing import Any
 
 from .config import Config
 from .config import get_metadata_filename
 from .config import IMAGES
 from .config import METADATA_DIR
 from .config import read_metadata
-
-
-def valid_str(value: Any) -> bool:
-    return isinstance(value, str) and len(value) > 0
 
 
 def validate(*, conf: Config) -> int:


### PR DESCRIPTION
Refactor usage of json-ly typed metadata files everywhere to use pydantic models. No more oopsies

To represent the states metadata can be in I have a `Metadata` class that represents the "final" state, and an `MetadataEditable` that represents one before its considered validateable.