### PR TITLE
Monthly pages as responsive column layout

### DIFF
--- a/src/dailyphoto/resources/month.css
+++ b/src/dailyphoto/resources/month.css
@@ -49,28 +49,33 @@ header h1 {
   border-radius: .5em 0em 0em .5em;
 }
 
-main {
+.grid-container {
+  column-count: 3;
+  column-gap: 1em;
+  row-gap: 1em
 }
 
-.flex-container {
-  display: flex;
-  flex-wrap: wrap;
-}
-
-.flex-item {
-  flex: 0 0 20%;
+.grid-item {
+  break-inside: avoid;
+  padding: 1em;
   box-sizing: border-box;
-  padding: 2%; /* optional spacing */
 }
 
-.flex-item img {
+.grid-item img {
   width: 100%;
   height: auto;
-  display: block;
+  border: 0.5em solid white;
 }
 
-img {
-  border: 0.5em solid white;
+@media (max-width: 1400px) {
+  .grid-container {
+    column-count: 2;
+  }
+}
+@media (max-width: 750px) {
+  .grid-container {
+    column-count: 1;
+  }
 }
 
 footer {

--- a/src/dailyphoto/resources/month.html
+++ b/src/dailyphoto/resources/month.html
@@ -16,9 +16,9 @@
       <h1>{{ month.strftime("%B, %Y") }}</h1>
       <a class="arrow arrow-right" href="{{ next }}"><div>&gt;</div></a>
     </header>
-    <main class="flex-container">
+    <main class="grid-container">
 {% for image in images %}
-      <div class="flex-item">
+      <div class="grid-item">
         <a href="{{ image.link }}">
           <img src="{{ image.file }}" alt="{{ image.alt }}" title="{{ image.alt }}">
         </a>


### PR DESCRIPTION
Use a column based layout instead of flexbox to create a faux "masonry" layout with pure CSS.
