### PR TITLE
Only load watchdog in dev

### DIFF
--- a/src/dailyphoto/cli.py
+++ b/src/dailyphoto/cli.py
@@ -1,8 +1,6 @@
 import argparse
 import logging
 
-from dailyphoto.watch import watch
-
 from . import config
 from .exif import print_exif
 from .generate import generate
@@ -134,7 +132,13 @@ def main(argv: list[str] | None = None) -> int:
     elif args.function == "generate":
         return generate(conf=conf, tar=args.tar)
     elif args.function == "watch":
-        return watch(conf=conf, path=args.path)
+        try:
+            from dailyphoto.watch import watch
+
+            return watch(conf=conf, path=args.path)
+        except ImportError:
+            print("Watch unavaiable without watchdog module")
+            return 1
     else:
         parser.parse_args(["-h"])
         return 1


### PR DESCRIPTION
The watchdog dependency isn't installed except for in dev. Make the loading conditional, and then print a cleaner error if it is called